### PR TITLE
Add Lambda Layers

### DIFF
--- a/dependencies/nodejs/package-lock.json
+++ b/dependencies/nodejs/package-lock.json
@@ -1,0 +1,100 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "aws-sdk": {
+      "version": "2.825.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.825.0.tgz",
+      "integrity": "sha512-b49nvaETm7uVRLf0FJ1CMmwCRVlLaxHtptVFuxX+2L4FR9VB0sLdgsxhtL3RVFbQlgVFNRV7fJUVK27mC++H+A==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/dependencies/nodejs/package.json
+++ b/dependencies/nodejs/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "aws-sdk": "^2.799.0"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -918,6 +918,7 @@
             "version": "2.825.0",
             "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.825.0.tgz",
             "integrity": "sha512-b49nvaETm7uVRLf0FJ1CMmwCRVlLaxHtptVFuxX+2L4FR9VB0sLdgsxhtL3RVFbQlgVFNRV7fJUVK27mC++H+A==",
+            "dev": true,
             "requires": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
@@ -1077,7 +1078,8 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
@@ -1126,6 +1128,7 @@
             "version": "4.9.2",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
             "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "dev": true,
             "requires": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4",
@@ -1586,7 +1589,8 @@
         "events": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "dev": true
         },
         "exec-sh": {
             "version": "0.3.4",
@@ -2082,7 +2086,8 @@
         "ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "dev": true
         },
         "import-local": {
             "version": "3.0.2",
@@ -2288,7 +2293,8 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -2899,7 +2905,8 @@
         "jmespath": {
             "version": "0.15.0",
             "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+            "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -3572,7 +3579,8 @@
         "punycode": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+            "dev": true
         },
         "qs": {
             "version": "6.5.2",
@@ -3583,7 +3591,8 @@
         "querystring": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
         },
         "react-is": {
             "version": "17.0.1",
@@ -3963,7 +3972,8 @@
         "sax": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+            "dev": true
         },
         "saxes": {
             "version": "5.0.1",
@@ -4653,6 +4663,7 @@
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
             "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "dev": true,
             "requires": {
                 "punycode": "1.3.2",
                 "querystring": "0.2.0"
@@ -4667,7 +4678,8 @@
         "uuid": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "dev": true
         },
         "v8-to-istanbul": {
             "version": "7.1.0",
@@ -4834,6 +4846,7 @@
             "version": "0.4.19",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
             "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "dev": true,
             "requires": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~9.0.1"
@@ -4842,7 +4855,8 @@
         "xmlbuilder": {
             "version": "9.0.7",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "dev": true
         },
         "xmlchars": {
             "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,8 @@
     "description": "template",
     "version": "0.0.1",
     "private": true,
-    "dependencies": {
-        "aws-sdk": "^2.799.0"
-    },
     "devDependencies": {
+        "aws-sdk": "^2.799.0",
         "@types/aws-lambda": "^8.10.51",
         "@types/node": "^13.13.5",
         "jest": "^26.6.3",
@@ -16,6 +14,7 @@
     "scripts": {
         "compile": "tsc",
         "deploy": "npm run compile && sam deploy",
+        "deploy:with-prune": "npm run compile && npm prune --production && sam deploy",
         "destroy": "aws cloudformation delete-stack --stack-name sam-app-template --region us-east-1",
         "test:unit": "npm run compile && jest --roots __tests__/unit",
         "test:integration": "jest --roots __tests__/integration",

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,0 +1,10 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "sam-app-template"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-xngv90lhexu1"
+s3_prefix = "sam-app-template"
+region = "us-east-1"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"

--- a/src/handlers/get-all-items.ts
+++ b/src/handlers/get-all-items.ts
@@ -15,6 +15,7 @@ export const handler = async (event: APIGatewayProxyEvent, context: unknown): Pr
         console.log(data.ConsumedCapacity)
         return successResponse(data.Items);
     } catch (error) {
+        console.log(error)
         return unexpectedErrorResponse(error);
     }
 }

--- a/src/handlers/get-by-id.ts
+++ b/src/handlers/get-by-id.ts
@@ -28,6 +28,7 @@ export const handler = async (event: APIGatewayProxyEvent, context: unknown): Pr
       return resourceNotFoundResponse()
     }
   } catch(error) {
+    console.log(error)
     return unexpectedErrorResponse(error)
   }
 }

--- a/src/handlers/put-item.ts
+++ b/src/handlers/put-item.ts
@@ -21,6 +21,7 @@ export const handler = async (event: APIGatewayProxyEvent, context: unknown): Pr
         console.log(result.ConsumedCapacity)
         return successResponse(body);
     } catch (error) {
+        console.log(error)
         return unexpectedErrorResponse(error);
     }
 }

--- a/template.yml
+++ b/template.yml
@@ -23,7 +23,8 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${AWS::StackName}-getAll
-      Handler: build/handlers/get-all-items.handler
+      CodeUri: build
+      Handler: handlers/get-all-items.handler
       Runtime: nodejs12.x
       MemorySize: 128
       Timeout: 100
@@ -36,6 +37,8 @@ Resources:
         Variables:
           # Make table name accessible as environment variable from function code during execution
           SAMPLE_TABLE: !Ref SampleTable
+      Layers:
+        - !Ref NPMDependenciesLayer
       Events:
         Api:
           Type: Api
@@ -50,7 +53,8 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${AWS::StackName}-getById
-      Handler: build/handlers/get-by-id.handler
+      CodeUri: build
+      Handler: handlers/get-by-id.handler
       Runtime: nodejs12.x
       MemorySize: 128
       Timeout: 100
@@ -63,6 +67,8 @@ Resources:
         Variables:
           # Make table name accessible as environment variable from function code during execution
           SAMPLE_TABLE: !Ref SampleTable
+      Layers:
+        - !Ref NPMDependenciesLayer
       Events:
         Api:
           Type: Api
@@ -77,7 +83,8 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${AWS::StackName}-put
-      Handler: build/handlers/put-item.handler
+      CodeUri: build
+      Handler: handlers/put-item.handler
       Runtime: nodejs12.x
       MemorySize: 128
       Timeout: 100
@@ -90,6 +97,8 @@ Resources:
         Variables:
           # Make table name accessible as environment variable from function code during execution
           SAMPLE_TABLE: !Ref SampleTable
+      Layers:
+        - !Ref NPMDependenciesLayer
       Events:
         Api:
           Type: Api
@@ -98,6 +107,17 @@ Resources:
             Method: POST
   # Simple syntax to create a DynamoDB table with a single attribute primary key, more in
   # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlesssimpletable
+
+  NPMDependenciesLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: npm-dependencies
+      Description: Dependencies for app [aws-sdk]
+      ContentUri: dependencies/
+      CompatibleRuntimes:
+        - nodejs12.x
+      LicenseInfo: 'MIT'
+      RetentionPolicy: Retain
 
   # DynamoDB table to store item: {id: &lt;ID&gt;, name: &lt;NAME&gt;}
   SampleTable:


### PR DESCRIPTION
1. Set `CodeUri` on functions to avoid uploading the entire project, including `node_modules`, on every deploy.

2. Add "layer " `dependencies/nodejs` for uploading runtime dependencies (since we're no longer getting them from the top level `node_modules` which includes our `devDependencies`). With this the dependencies are only re-uploaded when they change, not everytime the application source changes.

source: https://aws.amazon.com/blogs/compute/working-with-aws-lambda-and-lambda-layers-in-aws-sam/